### PR TITLE
Fix: when using Error.cause ensure older browsers/node still works

### DIFF
--- a/.changeset/metal-phones-hope.md
+++ b/.changeset/metal-phones-hope.md
@@ -1,0 +1,26 @@
+---
+'@belgattitude/http-exception': patch
+---
+
+Fix `Error.cause` on node < 16.9 and browsers that don't support for it.
+
+- **Browser** currently 89% support: [caniuse#error.cause](https://caniuse.com/mdn-javascript_builtins_error_error_options_cause_parameter) - (89% supports it as of sept 2022)
+- **Node** from 16.9.0 as per [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#browser_compatibility).
+
+The startegy used can be summarized as:
+
+> If the browser or the node runtime does not support Error.cause parameter in the
+> constructor, it will simply be discarded.
+> ie: 
+> ```
+> const err = new HttpNotFound({cause: new Error()});
+> console.log(err.cause) -> undefined if no support
+> console.log(err.cause) -> Error cause if supported
+> ```
+
+To enable older browser or previous node versions, there's 2 polyfills that should
+do the job
+
+- [error-cause-polyfill](https://github.com/ehmicky/error-cause-polyfill)
+- [error-cause](https://github.com/es-shims/error-cause)
+

--- a/.changeset/metal-phones-hope.md
+++ b/.changeset/metal-phones-hope.md
@@ -7,7 +7,7 @@ Fix `Error.cause` on node < 16.9 and browsers that don't support for it.
 - **Browser** currently 89% support: [caniuse#error.cause](https://caniuse.com/mdn-javascript_builtins_error_error_options_cause_parameter) - (89% supports it as of sept 2022)
 - **Node** from 16.9.0 as per [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#browser_compatibility).
 
-The startegy used can be summarized as:
+The strategy used can be summarized as:
 
 > If the browser or the node runtime does not support Error.cause parameter in the
 > constructor, it will simply be discarded.

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/packages/http-exception/.size-limit.cjs
+++ b/packages/http-exception/.size-limit.cjs
@@ -23,13 +23,13 @@ module.exports = [
     name: "ESM (only HttpNotFound exception)",
     path: ["dist/esm/index.mjs"],
     import: "{ HttpNotFound }",
-    limit: "1100B",
+    limit: "1150B",
   },
   {
     name: "ESM (only HttpInternalServerError)",
     path: ["dist/esm/index.mjs"],
     import: "{ HttpInternalServerError }",
-    limit: "1100B",
+    limit: "1150B",
   },
   {
     name: "ESM (two exceptions: HttpNotFound + HttpInternalServerError)",

--- a/packages/http-exception/docs/api/classes/base.HttpClientException.md
+++ b/packages/http-exception/docs/api/classes/base.HttpClientException.md
@@ -86,6 +86,7 @@ either a message or an object containing HttpExceptionParams
 
 ### Properties
 
+- [cause](base.HttpClientException.md#cause)
 - [statusCode](base.HttpClientException.md#statuscode)
 - [url](base.HttpClientException.md#url)
 
@@ -107,6 +108,23 @@ either a message or an object containing HttpExceptionParams
 [HttpException](base.HttpException.md).[constructor](base.HttpException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpException](base.HttpException.md).[cause](base.HttpException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/base.HttpException.md
+++ b/packages/http-exception/docs/api/classes/base.HttpException.md
@@ -22,6 +22,7 @@
 
 ### Properties
 
+- [cause](base.HttpException.md#cause)
 - [statusCode](base.HttpException.md#statuscode)
 - [url](base.HttpException.md#url)
 
@@ -45,6 +46,23 @@ Construct a new HttpException class
 Error.constructor
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Overrides
+
+Error.cause
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/base.HttpServerException.md
+++ b/packages/http-exception/docs/api/classes/base.HttpServerException.md
@@ -50,6 +50,7 @@ either a message or an object containing HttpExceptionParams
 
 ### Properties
 
+- [cause](base.HttpServerException.md#cause)
 - [statusCode](base.HttpServerException.md#statuscode)
 - [url](base.HttpServerException.md#url)
 
@@ -71,6 +72,23 @@ either a message or an object containing HttpExceptionParams
 [HttpException](base.HttpException.md).[constructor](base.HttpException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpException](base.HttpException.md).[cause](base.HttpException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpBadRequest.md
+++ b/packages/http-exception/docs/api/classes/client.HttpBadRequest.md
@@ -28,6 +28,7 @@ The server cannot or will not process the request due to something that is perce
 
 ### Properties
 
+- [cause](client.HttpBadRequest.md#cause)
 - [statusCode](client.HttpBadRequest.md#statuscode)
 - [url](client.HttpBadRequest.md#url)
 - [STATUS](client.HttpBadRequest.md#status)
@@ -49,6 +50,23 @@ The server cannot or will not process the request due to something that is perce
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpConflict.md
+++ b/packages/http-exception/docs/api/classes/client.HttpConflict.md
@@ -27,6 +27,7 @@ This response is sent when a request conflicts with the current state of the ser
 
 ### Properties
 
+- [cause](client.HttpConflict.md#cause)
 - [statusCode](client.HttpConflict.md#statuscode)
 - [url](client.HttpConflict.md#url)
 - [STATUS](client.HttpConflict.md#status)
@@ -48,6 +49,23 @@ This response is sent when a request conflicts with the current state of the ser
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpExpectationFailed.md
+++ b/packages/http-exception/docs/api/classes/client.HttpExpectationFailed.md
@@ -28,6 +28,7 @@ in the request's Expect header could not be met.
 
 ### Properties
 
+- [cause](client.HttpExpectationFailed.md#cause)
 - [statusCode](client.HttpExpectationFailed.md#statuscode)
 - [url](client.HttpExpectationFailed.md#url)
 - [STATUS](client.HttpExpectationFailed.md#status)
@@ -49,6 +50,23 @@ in the request's Expect header could not be met.
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpFailedDependency.md
+++ b/packages/http-exception/docs/api/classes/client.HttpFailedDependency.md
@@ -30,6 +30,7 @@ https://httpstatus.in/424/
 
 ### Properties
 
+- [cause](client.HttpFailedDependency.md#cause)
 - [statusCode](client.HttpFailedDependency.md#statuscode)
 - [url](client.HttpFailedDependency.md#url)
 - [STATUS](client.HttpFailedDependency.md#status)
@@ -51,6 +52,23 @@ https://httpstatus.in/424/
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpForbidden.md
+++ b/packages/http-exception/docs/api/classes/client.HttpForbidden.md
@@ -28,6 +28,7 @@ is refusing to give the requested resource. Unlike 401 Unauthorized, the client'
 
 ### Properties
 
+- [cause](client.HttpForbidden.md#cause)
 - [statusCode](client.HttpForbidden.md#statuscode)
 - [url](client.HttpForbidden.md#url)
 - [STATUS](client.HttpForbidden.md#status)
@@ -49,6 +50,23 @@ is refusing to give the requested resource. Unlike 401 Unauthorized, the client'
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpGone.md
+++ b/packages/http-exception/docs/api/classes/client.HttpGone.md
@@ -31,6 +31,7 @@ APIs should not feel compelled to indicate resources that have been deleted with
 
 ### Properties
 
+- [cause](client.HttpGone.md#cause)
 - [statusCode](client.HttpGone.md#statuscode)
 - [url](client.HttpGone.md#url)
 - [STATUS](client.HttpGone.md#status)
@@ -52,6 +53,23 @@ APIs should not feel compelled to indicate resources that have been deleted with
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpImATeapot.md
+++ b/packages/http-exception/docs/api/classes/client.HttpImATeapot.md
@@ -30,6 +30,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418
 
 ### Properties
 
+- [cause](client.HttpImATeapot.md#cause)
 - [statusCode](client.HttpImATeapot.md#statuscode)
 - [url](client.HttpImATeapot.md#url)
 - [STATUS](client.HttpImATeapot.md#status)
@@ -51,6 +52,23 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpLengthRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpLengthRequired.md
@@ -27,6 +27,7 @@ Server rejected the request because the Content-Length header field is not defin
 
 ### Properties
 
+- [cause](client.HttpLengthRequired.md#cause)
 - [statusCode](client.HttpLengthRequired.md#statuscode)
 - [url](client.HttpLengthRequired.md#url)
 - [STATUS](client.HttpLengthRequired.md#status)
@@ -48,6 +49,23 @@ Server rejected the request because the Content-Length header field is not defin
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpLocked.md
+++ b/packages/http-exception/docs/api/classes/client.HttpLocked.md
@@ -27,6 +27,7 @@ https://httpstatus.in/423/
 
 ### Properties
 
+- [cause](client.HttpLocked.md#cause)
 - [statusCode](client.HttpLocked.md#statuscode)
 - [url](client.HttpLocked.md#url)
 - [STATUS](client.HttpLocked.md#status)
@@ -48,6 +49,23 @@ https://httpstatus.in/423/
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpMethodNotAllowed.md
+++ b/packages/http-exception/docs/api/classes/client.HttpMethodNotAllowed.md
@@ -28,6 +28,7 @@ For example, an API may not allow calling DELETE to remove a resource.
 
 ### Properties
 
+- [cause](client.HttpMethodNotAllowed.md#cause)
 - [statusCode](client.HttpMethodNotAllowed.md#statuscode)
 - [url](client.HttpMethodNotAllowed.md#url)
 - [STATUS](client.HttpMethodNotAllowed.md#status)
@@ -49,6 +50,23 @@ For example, an API may not allow calling DELETE to remove a resource.
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpMisdirectedRequest.md
+++ b/packages/http-exception/docs/api/classes/client.HttpMisdirectedRequest.md
@@ -28,6 +28,7 @@ https://httpstatus.in/421/
 
 ### Properties
 
+- [cause](client.HttpMisdirectedRequest.md#cause)
 - [statusCode](client.HttpMisdirectedRequest.md#statuscode)
 - [url](client.HttpMisdirectedRequest.md#url)
 - [STATUS](client.HttpMisdirectedRequest.md#status)
@@ -49,6 +50,23 @@ https://httpstatus.in/421/
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpNotAcceptable.md
+++ b/packages/http-exception/docs/api/classes/client.HttpNotAcceptable.md
@@ -28,6 +28,7 @@ any content that conforms to the criteria given by the user agent.
 
 ### Properties
 
+- [cause](client.HttpNotAcceptable.md#cause)
 - [statusCode](client.HttpNotAcceptable.md#statuscode)
 - [url](client.HttpNotAcceptable.md#url)
 - [STATUS](client.HttpNotAcceptable.md#status)
@@ -49,6 +50,23 @@ any content that conforms to the criteria given by the user agent.
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpNotFound.md
+++ b/packages/http-exception/docs/api/classes/client.HttpNotFound.md
@@ -30,6 +30,7 @@ unauthorized client.
 
 ### Properties
 
+- [cause](client.HttpNotFound.md#cause)
 - [statusCode](client.HttpNotFound.md#statuscode)
 - [url](client.HttpNotFound.md#url)
 - [STATUS](client.HttpNotFound.md#status)
@@ -51,6 +52,23 @@ unauthorized client.
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpPayloadTooLarge.md
+++ b/packages/http-exception/docs/api/classes/client.HttpPayloadTooLarge.md
@@ -27,6 +27,7 @@ Request entity is larger than limits defined by server. The server might close t
 
 ### Properties
 
+- [cause](client.HttpPayloadTooLarge.md#cause)
 - [statusCode](client.HttpPayloadTooLarge.md#statuscode)
 - [url](client.HttpPayloadTooLarge.md#url)
 - [STATUS](client.HttpPayloadTooLarge.md#status)
@@ -48,6 +49,23 @@ Request entity is larger than limits defined by server. The server might close t
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpPaymentRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpPaymentRequired.md
@@ -28,6 +28,7 @@ payment systems, however this status code is used very rarely and no standard co
 
 ### Properties
 
+- [cause](client.HttpPaymentRequired.md#cause)
 - [statusCode](client.HttpPaymentRequired.md#statuscode)
 - [url](client.HttpPaymentRequired.md#url)
 - [STATUS](client.HttpPaymentRequired.md#status)
@@ -49,6 +50,23 @@ payment systems, however this status code is used very rarely and no standard co
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpPreconditionFailed.md
+++ b/packages/http-exception/docs/api/classes/client.HttpPreconditionFailed.md
@@ -27,6 +27,7 @@ The client has indicated preconditions in its headers which the server does not 
 
 ### Properties
 
+- [cause](client.HttpPreconditionFailed.md#cause)
 - [statusCode](client.HttpPreconditionFailed.md#statuscode)
 - [url](client.HttpPreconditionFailed.md#url)
 - [STATUS](client.HttpPreconditionFailed.md#status)
@@ -48,6 +49,23 @@ The client has indicated preconditions in its headers which the server does not 
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpPreconditionRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpPreconditionRequired.md
@@ -29,6 +29,7 @@ server, when meanwhile a third party has modified the state on the server, leadi
 
 ### Properties
 
+- [cause](client.HttpPreconditionRequired.md#cause)
 - [statusCode](client.HttpPreconditionRequired.md#statuscode)
 - [url](client.HttpPreconditionRequired.md#url)
 - [STATUS](client.HttpPreconditionRequired.md#status)
@@ -50,6 +51,23 @@ server, when meanwhile a third party has modified the state on the server, leadi
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpProxyAuthenticationRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpProxyAuthenticationRequired.md
@@ -27,6 +27,7 @@ This is similar to 401 Unauthorized but authentication is needed to be done by a
 
 ### Properties
 
+- [cause](client.HttpProxyAuthenticationRequired.md#cause)
 - [statusCode](client.HttpProxyAuthenticationRequired.md#statuscode)
 - [url](client.HttpProxyAuthenticationRequired.md#url)
 - [STATUS](client.HttpProxyAuthenticationRequired.md#status)
@@ -48,6 +49,23 @@ This is similar to 401 Unauthorized but authentication is needed to be done by a
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpRangeNotSatisfiable.md
+++ b/packages/http-exception/docs/api/classes/client.HttpRangeNotSatisfiable.md
@@ -28,6 +28,7 @@ It's possible that the range is outside the size of the target URI's data.
 
 ### Properties
 
+- [cause](client.HttpRangeNotSatisfiable.md#cause)
 - [statusCode](client.HttpRangeNotSatisfiable.md#statuscode)
 - [url](client.HttpRangeNotSatisfiable.md#url)
 - [STATUS](client.HttpRangeNotSatisfiable.md#status)
@@ -49,6 +50,23 @@ It's possible that the range is outside the size of the target URI's data.
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpRequestHeaderFieldsTooLarge.md
+++ b/packages/http-exception/docs/api/classes/client.HttpRequestHeaderFieldsTooLarge.md
@@ -28,6 +28,7 @@ The request may be resubmitted after reducing the size of the request header fie
 
 ### Properties
 
+- [cause](client.HttpRequestHeaderFieldsTooLarge.md#cause)
 - [statusCode](client.HttpRequestHeaderFieldsTooLarge.md#statuscode)
 - [url](client.HttpRequestHeaderFieldsTooLarge.md#url)
 - [STATUS](client.HttpRequestHeaderFieldsTooLarge.md#status)
@@ -49,6 +50,23 @@ The request may be resubmitted after reducing the size of the request header fie
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpRequestTimeout.md
+++ b/packages/http-exception/docs/api/classes/client.HttpRequestTimeout.md
@@ -30,6 +30,7 @@ Also note that some servers merely shut down the connection without sending this
 
 ### Properties
 
+- [cause](client.HttpRequestTimeout.md#cause)
 - [statusCode](client.HttpRequestTimeout.md#statuscode)
 - [url](client.HttpRequestTimeout.md#url)
 - [STATUS](client.HttpRequestTimeout.md#status)
@@ -51,6 +52,23 @@ Also note that some servers merely shut down the connection without sending this
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpTooEarly.md
+++ b/packages/http-exception/docs/api/classes/client.HttpTooEarly.md
@@ -26,6 +26,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425
 
 ### Properties
 
+- [cause](client.HttpTooEarly.md#cause)
 - [statusCode](client.HttpTooEarly.md#statuscode)
 - [url](client.HttpTooEarly.md#url)
 - [STATUS](client.HttpTooEarly.md#status)
@@ -47,6 +48,23 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpTooManyRequests.md
+++ b/packages/http-exception/docs/api/classes/client.HttpTooManyRequests.md
@@ -27,6 +27,7 @@ The user has sent too many requests in a given amount of time ("rate limiting").
 
 ### Properties
 
+- [cause](client.HttpTooManyRequests.md#cause)
 - [statusCode](client.HttpTooManyRequests.md#statuscode)
 - [url](client.HttpTooManyRequests.md#url)
 - [STATUS](client.HttpTooManyRequests.md#status)
@@ -48,6 +49,23 @@ The user has sent too many requests in a given amount of time ("rate limiting").
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpUnauthorized.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUnauthorized.md
@@ -28,6 +28,7 @@ That is, the client must authenticate itself to get the requested response.
 
 ### Properties
 
+- [cause](client.HttpUnauthorized.md#cause)
 - [statusCode](client.HttpUnauthorized.md#statuscode)
 - [url](client.HttpUnauthorized.md#url)
 - [STATUS](client.HttpUnauthorized.md#status)
@@ -49,6 +50,23 @@ That is, the client must authenticate itself to get the requested response.
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpUnavailableForLegalReasons.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUnavailableForLegalReasons.md
@@ -27,6 +27,7 @@ The user agent requested a resource that cannot legally be provided, such as a w
 
 ### Properties
 
+- [cause](client.HttpUnavailableForLegalReasons.md#cause)
 - [statusCode](client.HttpUnavailableForLegalReasons.md#statuscode)
 - [url](client.HttpUnavailableForLegalReasons.md#url)
 - [STATUS](client.HttpUnavailableForLegalReasons.md#status)
@@ -48,6 +49,23 @@ The user agent requested a resource that cannot legally be provided, such as a w
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpUnprocessableEntity.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUnprocessableEntity.md
@@ -32,6 +32,7 @@ For example, this error condition may occur if an XML request body contains well
 
 ### Properties
 
+- [cause](client.HttpUnprocessableEntity.md#cause)
 - [statusCode](client.HttpUnprocessableEntity.md#statuscode)
 - [url](client.HttpUnprocessableEntity.md#url)
 - [STATUS](client.HttpUnprocessableEntity.md#status)
@@ -53,6 +54,23 @@ For example, this error condition may occur if an XML request body contains well
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpUnsupportedMediaType.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUnsupportedMediaType.md
@@ -27,6 +27,7 @@ The media format of the requested data is not supported by the server, so the se
 
 ### Properties
 
+- [cause](client.HttpUnsupportedMediaType.md#cause)
 - [statusCode](client.HttpUnsupportedMediaType.md#statuscode)
 - [url](client.HttpUnsupportedMediaType.md#url)
 - [STATUS](client.HttpUnsupportedMediaType.md#status)
@@ -48,6 +49,23 @@ The media format of the requested data is not supported by the server, so the se
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpUpgradeRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUpgradeRequired.md
@@ -28,6 +28,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/426
 
 ### Properties
 
+- [cause](client.HttpUpgradeRequired.md#cause)
 - [statusCode](client.HttpUpgradeRequired.md#statuscode)
 - [url](client.HttpUpgradeRequired.md#url)
 - [STATUS](client.HttpUpgradeRequired.md#status)
@@ -49,6 +50,23 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/426
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/client.HttpUriTooLong.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUriTooLong.md
@@ -27,6 +27,7 @@ The URI requested by the client is longer than the server is willing to interpre
 
 ### Properties
 
+- [cause](client.HttpUriTooLong.md#cause)
 - [statusCode](client.HttpUriTooLong.md#statuscode)
 - [url](client.HttpUriTooLong.md#url)
 - [STATUS](client.HttpUriTooLong.md#status)
@@ -48,6 +49,23 @@ The URI requested by the client is longer than the server is willing to interpre
 [HttpClientException](base.HttpClientException.md).[constructor](base.HttpClientException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[cause](base.HttpClientException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpBadGateway.md
+++ b/packages/http-exception/docs/api/classes/server.HttpBadGateway.md
@@ -27,6 +27,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502
 
 ### Properties
 
+- [cause](server.HttpBadGateway.md#cause)
 - [statusCode](server.HttpBadGateway.md#statuscode)
 - [url](server.HttpBadGateway.md#url)
 - [STATUS](server.HttpBadGateway.md#status)
@@ -48,6 +49,23 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpGatewayTimeout.md
+++ b/packages/http-exception/docs/api/classes/server.HttpGatewayTimeout.md
@@ -27,6 +27,7 @@ This error response is given when the server is acting as a gateway and cannot g
 
 ### Properties
 
+- [cause](server.HttpGatewayTimeout.md#cause)
 - [statusCode](server.HttpGatewayTimeout.md#statuscode)
 - [url](server.HttpGatewayTimeout.md#url)
 - [STATUS](server.HttpGatewayTimeout.md#status)
@@ -48,6 +49,23 @@ This error response is given when the server is acting as a gateway and cannot g
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpInsufficientStorage.md
+++ b/packages/http-exception/docs/api/classes/server.HttpInsufficientStorage.md
@@ -27,6 +27,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/507
 
 ### Properties
 
+- [cause](server.HttpInsufficientStorage.md#cause)
 - [statusCode](server.HttpInsufficientStorage.md#statuscode)
 - [url](server.HttpInsufficientStorage.md#url)
 - [STATUS](server.HttpInsufficientStorage.md#status)
@@ -48,6 +49,23 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/507
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpInternalServerError.md
+++ b/packages/http-exception/docs/api/classes/server.HttpInternalServerError.md
@@ -27,6 +27,7 @@ The server has encountered a situation it does not know how to handle.
 
 ### Properties
 
+- [cause](server.HttpInternalServerError.md#cause)
 - [statusCode](server.HttpInternalServerError.md#statuscode)
 - [url](server.HttpInternalServerError.md#url)
 - [STATUS](server.HttpInternalServerError.md#status)
@@ -48,6 +49,23 @@ The server has encountered a situation it does not know how to handle.
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpLoopDetected.md
+++ b/packages/http-exception/docs/api/classes/server.HttpLoopDetected.md
@@ -27,6 +27,7 @@ The server detected an infinite loop while processing the request.
 
 ### Properties
 
+- [cause](server.HttpLoopDetected.md#cause)
 - [statusCode](server.HttpLoopDetected.md#statuscode)
 - [url](server.HttpLoopDetected.md#url)
 - [STATUS](server.HttpLoopDetected.md#status)
@@ -48,6 +49,23 @@ The server detected an infinite loop while processing the request.
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpNetworkAuthenticationRequired.md
+++ b/packages/http-exception/docs/api/classes/server.HttpNetworkAuthenticationRequired.md
@@ -27,6 +27,7 @@ Indicates that the client needs to authenticate to gain network access.
 
 ### Properties
 
+- [cause](server.HttpNetworkAuthenticationRequired.md#cause)
 - [statusCode](server.HttpNetworkAuthenticationRequired.md#statuscode)
 - [url](server.HttpNetworkAuthenticationRequired.md#url)
 - [STATUS](server.HttpNetworkAuthenticationRequired.md#status)
@@ -48,6 +49,23 @@ Indicates that the client needs to authenticate to gain network access.
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpNotExtended.md
+++ b/packages/http-exception/docs/api/classes/server.HttpNotExtended.md
@@ -27,6 +27,7 @@ Further extensions to the request are required for the server to fulfill it.
 
 ### Properties
 
+- [cause](server.HttpNotExtended.md#cause)
 - [statusCode](server.HttpNotExtended.md#statuscode)
 - [url](server.HttpNotExtended.md#url)
 - [STATUS](server.HttpNotExtended.md#status)
@@ -48,6 +49,23 @@ Further extensions to the request are required for the server to fulfill it.
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpNotImplemented.md
+++ b/packages/http-exception/docs/api/classes/server.HttpNotImplemented.md
@@ -28,6 +28,7 @@ servers are required to support (and therefore that must not return this code) a
 
 ### Properties
 
+- [cause](server.HttpNotImplemented.md#cause)
 - [statusCode](server.HttpNotImplemented.md#statuscode)
 - [url](server.HttpNotImplemented.md#url)
 - [STATUS](server.HttpNotImplemented.md#status)
@@ -49,6 +50,23 @@ servers are required to support (and therefore that must not return this code) a
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpServiceUnavailable.md
+++ b/packages/http-exception/docs/api/classes/server.HttpServiceUnavailable.md
@@ -34,6 +34,7 @@ should usually not be cached.
 
 ### Properties
 
+- [cause](server.HttpServiceUnavailable.md#cause)
 - [statusCode](server.HttpServiceUnavailable.md#statuscode)
 - [url](server.HttpServiceUnavailable.md#url)
 - [STATUS](server.HttpServiceUnavailable.md#status)
@@ -55,6 +56,23 @@ should usually not be cached.
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpVariantAlsoNegotiates.md
+++ b/packages/http-exception/docs/api/classes/server.HttpVariantAlsoNegotiates.md
@@ -28,6 +28,7 @@ in transparent content negotiation itself, and is therefore not a proper end poi
 
 ### Properties
 
+- [cause](server.HttpVariantAlsoNegotiates.md#cause)
 - [statusCode](server.HttpVariantAlsoNegotiates.md#statuscode)
 - [url](server.HttpVariantAlsoNegotiates.md#url)
 - [STATUS](server.HttpVariantAlsoNegotiates.md#status)
@@ -49,6 +50,23 @@ in transparent content negotiation itself, and is therefore not a proper end poi
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/classes/server.HttpVersionNotSupported.md
+++ b/packages/http-exception/docs/api/classes/server.HttpVersionNotSupported.md
@@ -27,6 +27,7 @@ The HTTP version used in the request is not supported by the server.
 
 ### Properties
 
+- [cause](server.HttpVersionNotSupported.md#cause)
 - [statusCode](server.HttpVersionNotSupported.md#statuscode)
 - [url](server.HttpVersionNotSupported.md#url)
 - [STATUS](server.HttpVersionNotSupported.md#status)
@@ -48,6 +49,23 @@ The HTTP version used in the request is not supported by the server.
 [HttpServerException](base.HttpServerException.md).[constructor](base.HttpServerException.md#constructor)
 
 ## Properties
+
+### cause
+
+• `Optional` `Readonly` **cause**: `Error`
+
+If set and the runtime (browser or node) supports it
+you can get back the error cause
+
+**`See`**
+
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[cause](base.HttpServerException.md#cause)
+
+---
 
 ### statusCode
 

--- a/packages/http-exception/docs/api/modules/typeguards.md
+++ b/packages/http-exception/docs/api/modules/typeguards.md
@@ -32,9 +32,15 @@ error is HttpClientException
 
 ### isHttpErrorStatusCode
 
-▸ **isHttpErrorStatusCode**(`statusCode`): statusCode is number
+▸ **isHttpErrorStatusCode**<`T`\>(`statusCode`): statusCode is T
 
 Check if the provided value is a valid http status code
+
+#### Type parameters
+
+| Name | Type                        |
+| :--- | :-------------------------- |
+| `T`  | extends `number` = `number` |
 
 #### Parameters
 
@@ -44,7 +50,7 @@ Check if the provided value is a valid http status code
 
 #### Returns
 
-statusCode is number
+statusCode is T
 
 ---
 

--- a/packages/http-exception/docs/api/modules/types.md
+++ b/packages/http-exception/docs/api/modules/types.md
@@ -25,11 +25,11 @@
 
 #### Type declaration
 
-| Name       | Type     | Description                                                                                                                                              |
-| :--------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cause?`   | `Error`  | Indicates the original cause of the HttpException **`See`** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause |
-| `message?` | `string` | Exception message, if not provided the default is the exception name in natural language (ie: "HttpNotFound" -> "Not found")                             |
-| `url?`     | `string` | Indicates the original url that caused the error.                                                                                                        |
+| Name       | Type     | Description                                                                                                                                                                                                                                                            |
+| :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cause?`   | `Error`  | Indicates the original cause of the HttpException. Will be ignored/discarded if the runtime (browser / node version) does not support it or there's no polyfill **`See`** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause |
+| `message?` | `string` | Exception message, if not provided the default is the exception name in natural language (ie: "HttpNotFound" -> "Not found")                                                                                                                                           |
+| `url?`     | `string` | Indicates the original url that caused the error.                                                                                                                                                                                                                      |
 
 ---
 

--- a/packages/http-exception/package.json
+++ b/packages/http-exception/package.json
@@ -74,6 +74,7 @@
     "@vitest/ui": "0.23.4",
     "corejs": "1.0.0",
     "cross-env": "7.0.3",
+    "error-cause-polyfill": "1.1.0",
     "es-check": "7.0.1",
     "eslint": "8.23.1",
     "get-tsconfig": "4.2.0",

--- a/packages/http-exception/src/__tests__/cause.test.ts
+++ b/packages/http-exception/src/__tests__/cause.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, expect, vi } from 'vitest';
+import { HttpClientException, HttpException } from '../base';
+import { HttpNotFound } from '../client';
+import { supportsErrorCause } from '../support';
+
+describe(`when Error.cause isn't supported`, () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  const cause = new Error('cause');
+  const params = {
+    cause,
+  };
+
+  const scenarios: [name: string, cls: HttpException][] = [
+    ['HttpException', new HttpException(500, params)],
+    ['HttpClientExeption', new HttpClientException(404, params)],
+    ['HttpServerExeption', new HttpClientException(500, params)],
+    ['HttpNotFound', new HttpNotFound(params)],
+  ];
+
+  vi.mock('../support', () => {
+    return {
+      supportsErrorCause: () => false,
+    };
+  });
+
+  it.each(scenarios)('should ignore the cause for %s.', (name, err) => {
+    expect(supportsErrorCause()).toStrictEqual(false);
+    expect(err.cause).toStrictEqual(undefined);
+  });
+});

--- a/packages/http-exception/src/base/HttpException.ts
+++ b/packages/http-exception/src/base/HttpException.ts
@@ -1,3 +1,4 @@
+import { supportsErrorCause } from '../support';
 import type { HttpExceptionParams } from '../types';
 import { getSuper } from '../utils';
 
@@ -12,6 +13,13 @@ export class HttpException extends Error {
   public readonly url: string | undefined;
 
   /**
+   * If set and the runtime (browser or node) supports it
+   * you can get back the error cause
+   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+   */
+  public readonly cause?: Error;
+
+  /**
    * Construct a new HttpException class
    *
    * @param statusCode http status code between 400-599, no checks are done on the validity of the number.
@@ -20,7 +28,7 @@ export class HttpException extends Error {
   constructor(statusCode: number, msgOrParams?: HttpExceptionParams | string) {
     const name = 'HttpException';
     const { message, url, cause } = getSuper(name, msgOrParams);
-    if (cause) {
+    if (supportsErrorCause() && cause) {
       super(message, { cause });
     } else {
       super(message);

--- a/packages/http-exception/src/support/index.js
+++ b/packages/http-exception/src/support/index.js
@@ -1,0 +1,1 @@
+export { supportsErrorCause } from './supportsErrorCause';

--- a/packages/http-exception/src/support/supportsErrorCause.ts
+++ b/packages/http-exception/src/support/supportsErrorCause.ts
@@ -1,0 +1,4 @@
+export const supportsErrorCause = () => {
+  const cause = Symbol('');
+  return new Error('test', { cause }).cause === cause;
+};

--- a/packages/http-exception/src/types/HttpExceptionParams.ts
+++ b/packages/http-exception/src/types/HttpExceptionParams.ts
@@ -9,7 +9,9 @@ export type HttpExceptionParams = {
    */
   url?: string;
   /**
-   * Indicates the original cause of the HttpException
+   * Indicates the original cause of the HttpException.
+   * Will be ignored/discarded if the runtime (browser / node version) does not support it
+   * or there's no polyfill
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
    */
   cause?: Error;

--- a/packages/http-exception/test/setupVitest.ts
+++ b/packages/http-exception/test/setupVitest.ts
@@ -1,0 +1,4 @@
+/**
+ * To make tests run on node 14.x we can load a polyfill
+ */
+import 'error-cause-polyfill/auto';

--- a/packages/http-exception/vitest.config.ts
+++ b/packages/http-exception/vitest.config.ts
@@ -3,12 +3,15 @@ import { defineConfig } from 'vitest/config';
 
 const testFiles = ['./src/**/*.test.{js,ts}'];
 
+import 'error-cause-polyfill/auto';
+
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     globals: true,
     environment: 'node',
     passWithNoTests: false,
+    setupFiles: './test/setupVitest.ts',
     cache: {
       dir: '../../.cache/vitest/errorh',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1566,6 +1566,7 @@ __metadata:
     "@vitest/ui": "npm:0.23.4"
     corejs: "npm:1.0.0"
     cross-env: "npm:7.0.3"
+    error-cause-polyfill: "npm:1.1.0"
     es-check: "npm:7.0.1"
     eslint: "npm:8.23.1"
     get-tsconfig: "npm:4.2.0"
@@ -5897,6 +5898,13 @@ __metadata:
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
   checksum: 12244d58c3eeb73a5ebf633ff615b2366cedaccfea3c2b4d6a3295f6440661052e9574c71f89d6dc8a5466e3d84be0b1994e2a4017ab10e1f037f8be1ca89a37
+  languageName: node
+  linkType: hard
+
+"error-cause-polyfill@npm:1.1.0":
+  version: 1.1.0
+  resolution: "error-cause-polyfill@npm:1.1.0"
+  checksum: efbf48634a79a11496eff7ba66a5b4179cef80769fd49271d4576fac95fe83acb61e37dfd7aed1836cc999a11cef5897cc7458288067dce22ac3c25487b480af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix `Error.cause` on node < 16.9 and browsers that don't support for it.

- **Browser** currently 89% support: [caniuse#error.cause](https://caniuse.com/mdn-javascript_builtins_error_error_options_cause_parameter) - (89% supports it as of sept 2022)
- **Node** from 16.9.0 as per [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#browser_compatibility).

The strategy used can be summarized as:

> If the browser or the node runtime does not support Error.cause parameter in the
> constructor, it will simply be discarded.
> ie: 
> ```
> const err = new HttpNotFound({cause: new Error()});
> console.log(err.cause) -> undefined if no support
> console.log(err.cause) -> Error cause if supported
> ```

To enable older browser or previous node versions, there's 2 polyfills that should
do the job

- [error-cause-polyfill](https://github.com/ehmicky/error-cause-polyfill)
- [error-cause](https://github.com/es-shims/error-cause)

