### PR TITLE
Expose serializable functions

### DIFF
--- a/.changeset/curly-dragons-tickle.md
+++ b/.changeset/curly-dragons-tickle.md
@@ -1,0 +1,15 @@
+---
+'@belgattitude/http-exception': minor
+---
+
+Export convertToSerializable and createFromSerializable
+
+```typescript
+import { 
+    convertToSerializable, 
+    createFromSerializable 
+} from '@belgattitude/http-exception/serializer';
+
+const serializableObject = convertToSerializable(new HttpForbidden()); 
+const exception = createFromSerializable(serializableObject);
+```

--- a/packages/http-exception/src/serializer/index.ts
+++ b/packages/http-exception/src/serializer/index.ts
@@ -1,3 +1,9 @@
 export { toJson, fromJson } from './json';
 export { SerializerError } from './error';
-export type { NativeError } from './types';
+export type {
+  NativeError,
+  SerializableError,
+  SerializableHttpException,
+  SerializableNonNativeError,
+} from './types';
+export { convertToSerializable, createFromSerializable } from './mapper';


### PR DESCRIPTION
Export convertToSerializable and createFromSerializable

```typescript
import { 
    convertToSerializable, 
    createFromSerializable 
} from '@belgattitude/http-exception/serializer';

const serializableObject = convertToSerializable(new HttpForbidden()); 
const exception = createFromSerializable(serializableObject);
```
