### PR TITLE
New props: method, code, errorId

### DIFF
--- a/.changeset/rare-rules-return.md
+++ b/.changeset/rare-rules-return.md
@@ -2,7 +2,7 @@
 '@belgattitude/http-exception': minor
 ---
 
-Added `method`, `code` and `errorId params.
+Added `method`, `code` and `errorId` params.
 
 | Name      | Type      | Description                                           |
 |-----------| --------- |-------------------------------------------------------|

--- a/.changeset/rare-rules-return.md
+++ b/.changeset/rare-rules-return.md
@@ -1,0 +1,22 @@
+---
+'@belgattitude/http-exception': minor
+---
+
+Added `method`, `code` and `errorId params.
+
+| Name      | Type      | Description                                           |
+|-----------| --------- |-------------------------------------------------------|
+| url       | `string?` | url on which the error happened                       |
+| method    | `string?` | http method used to load the url                      |
+| code      | `string?` | Custom code (ie: 'AbortError', 'E-1234'...) |
+| errorId   | `string?` | Unique error identifier (ie: uuid, nanoid...)         |
+
+```typescript
+const err = new HttpRequestTimeout({
+  url: "https://api.dev/user/belgattitude",
+  method: "GET",
+  code: "NETWORK_FAILURE",
+  errorId: nanoid(), // can be shared by frontend/backend 
+});
+console.log(err.url, err.method, err.code, err.errorId);
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -261,15 +261,21 @@ const e4 = createHttpException(HttpMethodNotAllowed.STATUS, {
 
 It's possible to attach a context to the exception (for logging, reporting...). This can be done by passing the following parameters to [HttpExceptionParams](#httpexception-parameters).
 
-| Name | Type      | Description                     |
-| ---- | --------- | ------------------------------- |
-| url  | `string?` | url on which the error happened |
+| Name    | Type      | Description                                                    |
+| ------- | --------- | -------------------------------------------------------------- |
+| url     | `string?` | url on which the error happened                                |
+| method  | `string?` | http method used to load the url                               |
+| code    | `string?` | Custom code (ie: 'NETWORK_FAILURE', 'AbortError', 'E-1234'...) |
+| errorId | `string?` | Unique error identifier (ie: uuid, nanoid...)                  |
 
 ```typescript
-const err = new HttpNotFound({
+const err = new HttpRequestTimeout({
   url: "https://api.dev/user/belgattitude",
+  method: "GET",
+  code: "NETWORK_FAILURE",
+  errorId: nanoid(),
 });
-console.log(err.url);
+console.log(err.url, err.method, err.code, err.errorId);
 ```
 
 > **Note**

--- a/packages/http-exception/.size-limit.cjs
+++ b/packages/http-exception/.size-limit.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-const fullEsmMaxSize = "2900B";
+const fullEsmMaxSize = "2910B";
 const fullCjsMaxSize = "3100B";
 
 /**
@@ -23,25 +23,25 @@ module.exports = [
     name: "ESM (only HttpNotFound exception)",
     path: ["dist/esm/index.js"],
     import: "{ HttpNotFound }",
-    limit: "1150B",
+    limit: "1200B",
   },
   {
     name: "ESM (only HttpInternalServerError)",
     path: ["dist/esm/index.js"],
     import: "{ HttpInternalServerError }",
-    limit: "1150B",
+    limit: "1200B",
   },
   {
     name: "ESM (two exceptions: HttpNotFound + HttpInternalServerError)",
     path: ["dist/esm/index.js"],
     import: "{ HttpNotFound, HttpInternalServerError }",
-    limit: "1200B",
+    limit: "1250B",
   },
   {
     name: "ESM (only isHttpException)",
     path: ["dist/esm/index.js"],
     import: "{ isHttpException }",
-    limit: "1000B",
+    limit: "1050B",
   },
   {
     name: "ESM (only createHttpException)",
@@ -53,13 +53,13 @@ module.exports = [
     name: "ESM ({ toJson })",
     path: ["dist/esm/serializer/index.js"],
     import: "{ toJson }",
-    limit: "1800B",
+    limit: "1850B",
   },
   {
     name: "ESM ({ fromJson })",
     path: ["dist/esm/serializer/index.js"],
     import: "{ fromJson }",
-    limit: "3100B",
+    limit: "3110B",
   },
   // ###################################################
   // Commonjs full bundle

--- a/packages/http-exception/docs/api/classes/base.HttpClientException.md
+++ b/packages/http-exception/docs/api/classes/base.HttpClientException.md
@@ -87,7 +87,10 @@ either a message or an object containing HttpExceptionParams
 ### Properties
 
 - [cause](base.HttpClientException.md#cause)
+- [code](base.HttpClientException.md#code)
+- [errorId](base.HttpClientException.md#errorid)
 - [message](base.HttpClientException.md#message)
+- [method](base.HttpClientException.md#method)
 - [name](base.HttpClientException.md#name)
 - [stack](base.HttpClientException.md#stack)
 - [statusCode](base.HttpClientException.md#statuscode)
@@ -120,7 +123,7 @@ either a message or an object containing HttpExceptionParams
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -135,6 +138,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpException](base.HttpException.md).[code](base.HttpException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpException](base.HttpException.md).[errorId](base.HttpException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -142,6 +169,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpException](base.HttpException.md).[message](base.HttpException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpException](base.HttpException.md).[method](base.HttpException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/base.HttpException.md
+++ b/packages/http-exception/docs/api/classes/base.HttpException.md
@@ -23,7 +23,10 @@
 ### Properties
 
 - [cause](base.HttpException.md#cause)
+- [code](base.HttpException.md#code)
+- [errorId](base.HttpException.md#errorid)
 - [message](base.HttpException.md#message)
+- [method](base.HttpException.md#method)
 - [name](base.HttpException.md#name)
 - [stack](base.HttpException.md#stack)
 - [statusCode](base.HttpException.md#statuscode)
@@ -58,7 +61,7 @@ Error.constructor
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -73,6 +76,22 @@ Error.cause
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -80,6 +99,14 @@ Error.cause
 #### Inherited from
 
 Error.message
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
 
 ---
 

--- a/packages/http-exception/docs/api/classes/base.HttpServerException.md
+++ b/packages/http-exception/docs/api/classes/base.HttpServerException.md
@@ -51,7 +51,10 @@ either a message or an object containing HttpExceptionParams
 ### Properties
 
 - [cause](base.HttpServerException.md#cause)
+- [code](base.HttpServerException.md#code)
+- [errorId](base.HttpServerException.md#errorid)
 - [message](base.HttpServerException.md#message)
+- [method](base.HttpServerException.md#method)
 - [name](base.HttpServerException.md#name)
 - [stack](base.HttpServerException.md#stack)
 - [statusCode](base.HttpServerException.md#statuscode)
@@ -84,7 +87,7 @@ either a message or an object containing HttpExceptionParams
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -99,6 +102,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpException](base.HttpException.md).[code](base.HttpException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpException](base.HttpException.md).[errorId](base.HttpException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -106,6 +133,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpException](base.HttpException.md).[message](base.HttpException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpException](base.HttpException.md).[method](base.HttpException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpBadRequest.md
+++ b/packages/http-exception/docs/api/classes/client.HttpBadRequest.md
@@ -29,7 +29,10 @@ The server cannot or will not process the request due to something that is perce
 ### Properties
 
 - [cause](client.HttpBadRequest.md#cause)
+- [code](client.HttpBadRequest.md#code)
+- [errorId](client.HttpBadRequest.md#errorid)
 - [message](client.HttpBadRequest.md#message)
+- [method](client.HttpBadRequest.md#method)
 - [name](client.HttpBadRequest.md#name)
 - [stack](client.HttpBadRequest.md#stack)
 - [statusCode](client.HttpBadRequest.md#statuscode)
@@ -62,7 +65,7 @@ The server cannot or will not process the request due to something that is perce
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpConflict.md
+++ b/packages/http-exception/docs/api/classes/client.HttpConflict.md
@@ -28,7 +28,10 @@ This response is sent when a request conflicts with the current state of the ser
 ### Properties
 
 - [cause](client.HttpConflict.md#cause)
+- [code](client.HttpConflict.md#code)
+- [errorId](client.HttpConflict.md#errorid)
 - [message](client.HttpConflict.md#message)
+- [method](client.HttpConflict.md#method)
 - [name](client.HttpConflict.md#name)
 - [stack](client.HttpConflict.md#stack)
 - [statusCode](client.HttpConflict.md#statuscode)
@@ -61,7 +64,7 @@ This response is sent when a request conflicts with the current state of the ser
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpExpectationFailed.md
+++ b/packages/http-exception/docs/api/classes/client.HttpExpectationFailed.md
@@ -29,7 +29,10 @@ in the request's Expect header could not be met.
 ### Properties
 
 - [cause](client.HttpExpectationFailed.md#cause)
+- [code](client.HttpExpectationFailed.md#code)
+- [errorId](client.HttpExpectationFailed.md#errorid)
 - [message](client.HttpExpectationFailed.md#message)
+- [method](client.HttpExpectationFailed.md#method)
 - [name](client.HttpExpectationFailed.md#name)
 - [stack](client.HttpExpectationFailed.md#stack)
 - [statusCode](client.HttpExpectationFailed.md#statuscode)
@@ -62,7 +65,7 @@ in the request's Expect header could not be met.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpFailedDependency.md
+++ b/packages/http-exception/docs/api/classes/client.HttpFailedDependency.md
@@ -31,7 +31,10 @@ https://httpstatus.in/424/
 ### Properties
 
 - [cause](client.HttpFailedDependency.md#cause)
+- [code](client.HttpFailedDependency.md#code)
+- [errorId](client.HttpFailedDependency.md#errorid)
 - [message](client.HttpFailedDependency.md#message)
+- [method](client.HttpFailedDependency.md#method)
 - [name](client.HttpFailedDependency.md#name)
 - [stack](client.HttpFailedDependency.md#stack)
 - [statusCode](client.HttpFailedDependency.md#statuscode)
@@ -64,7 +67,7 @@ https://httpstatus.in/424/
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -79,6 +82,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -86,6 +113,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpForbidden.md
+++ b/packages/http-exception/docs/api/classes/client.HttpForbidden.md
@@ -29,7 +29,10 @@ is refusing to give the requested resource. Unlike 401 Unauthorized, the client'
 ### Properties
 
 - [cause](client.HttpForbidden.md#cause)
+- [code](client.HttpForbidden.md#code)
+- [errorId](client.HttpForbidden.md#errorid)
 - [message](client.HttpForbidden.md#message)
+- [method](client.HttpForbidden.md#method)
 - [name](client.HttpForbidden.md#name)
 - [stack](client.HttpForbidden.md#stack)
 - [statusCode](client.HttpForbidden.md#statuscode)
@@ -62,7 +65,7 @@ is refusing to give the requested resource. Unlike 401 Unauthorized, the client'
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpGone.md
+++ b/packages/http-exception/docs/api/classes/client.HttpGone.md
@@ -32,7 +32,10 @@ APIs should not feel compelled to indicate resources that have been deleted with
 ### Properties
 
 - [cause](client.HttpGone.md#cause)
+- [code](client.HttpGone.md#code)
+- [errorId](client.HttpGone.md#errorid)
 - [message](client.HttpGone.md#message)
+- [method](client.HttpGone.md#method)
 - [name](client.HttpGone.md#name)
 - [stack](client.HttpGone.md#stack)
 - [statusCode](client.HttpGone.md#statuscode)
@@ -65,7 +68,7 @@ APIs should not feel compelled to indicate resources that have been deleted with
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -80,6 +83,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -87,6 +114,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpImATeapot.md
+++ b/packages/http-exception/docs/api/classes/client.HttpImATeapot.md
@@ -31,7 +31,10 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418
 ### Properties
 
 - [cause](client.HttpImATeapot.md#cause)
+- [code](client.HttpImATeapot.md#code)
+- [errorId](client.HttpImATeapot.md#errorid)
 - [message](client.HttpImATeapot.md#message)
+- [method](client.HttpImATeapot.md#method)
 - [name](client.HttpImATeapot.md#name)
 - [stack](client.HttpImATeapot.md#stack)
 - [statusCode](client.HttpImATeapot.md#statuscode)
@@ -64,7 +67,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -79,6 +82,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -86,6 +113,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpLengthRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpLengthRequired.md
@@ -28,7 +28,10 @@ Server rejected the request because the Content-Length header field is not defin
 ### Properties
 
 - [cause](client.HttpLengthRequired.md#cause)
+- [code](client.HttpLengthRequired.md#code)
+- [errorId](client.HttpLengthRequired.md#errorid)
 - [message](client.HttpLengthRequired.md#message)
+- [method](client.HttpLengthRequired.md#method)
 - [name](client.HttpLengthRequired.md#name)
 - [stack](client.HttpLengthRequired.md#stack)
 - [statusCode](client.HttpLengthRequired.md#statuscode)
@@ -61,7 +64,7 @@ Server rejected the request because the Content-Length header field is not defin
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpLocked.md
+++ b/packages/http-exception/docs/api/classes/client.HttpLocked.md
@@ -28,7 +28,10 @@ https://httpstatus.in/423/
 ### Properties
 
 - [cause](client.HttpLocked.md#cause)
+- [code](client.HttpLocked.md#code)
+- [errorId](client.HttpLocked.md#errorid)
 - [message](client.HttpLocked.md#message)
+- [method](client.HttpLocked.md#method)
 - [name](client.HttpLocked.md#name)
 - [stack](client.HttpLocked.md#stack)
 - [statusCode](client.HttpLocked.md#statuscode)
@@ -61,7 +64,7 @@ https://httpstatus.in/423/
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpMethodNotAllowed.md
+++ b/packages/http-exception/docs/api/classes/client.HttpMethodNotAllowed.md
@@ -29,7 +29,10 @@ For example, an API may not allow calling DELETE to remove a resource.
 ### Properties
 
 - [cause](client.HttpMethodNotAllowed.md#cause)
+- [code](client.HttpMethodNotAllowed.md#code)
+- [errorId](client.HttpMethodNotAllowed.md#errorid)
 - [message](client.HttpMethodNotAllowed.md#message)
+- [method](client.HttpMethodNotAllowed.md#method)
 - [name](client.HttpMethodNotAllowed.md#name)
 - [stack](client.HttpMethodNotAllowed.md#stack)
 - [statusCode](client.HttpMethodNotAllowed.md#statuscode)
@@ -62,7 +65,7 @@ For example, an API may not allow calling DELETE to remove a resource.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpMisdirectedRequest.md
+++ b/packages/http-exception/docs/api/classes/client.HttpMisdirectedRequest.md
@@ -29,7 +29,10 @@ https://httpstatus.in/421/
 ### Properties
 
 - [cause](client.HttpMisdirectedRequest.md#cause)
+- [code](client.HttpMisdirectedRequest.md#code)
+- [errorId](client.HttpMisdirectedRequest.md#errorid)
 - [message](client.HttpMisdirectedRequest.md#message)
+- [method](client.HttpMisdirectedRequest.md#method)
 - [name](client.HttpMisdirectedRequest.md#name)
 - [stack](client.HttpMisdirectedRequest.md#stack)
 - [statusCode](client.HttpMisdirectedRequest.md#statuscode)
@@ -62,7 +65,7 @@ https://httpstatus.in/421/
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpNotAcceptable.md
+++ b/packages/http-exception/docs/api/classes/client.HttpNotAcceptable.md
@@ -29,7 +29,10 @@ any content that conforms to the criteria given by the user agent.
 ### Properties
 
 - [cause](client.HttpNotAcceptable.md#cause)
+- [code](client.HttpNotAcceptable.md#code)
+- [errorId](client.HttpNotAcceptable.md#errorid)
 - [message](client.HttpNotAcceptable.md#message)
+- [method](client.HttpNotAcceptable.md#method)
 - [name](client.HttpNotAcceptable.md#name)
 - [stack](client.HttpNotAcceptable.md#stack)
 - [statusCode](client.HttpNotAcceptable.md#statuscode)
@@ -62,7 +65,7 @@ any content that conforms to the criteria given by the user agent.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpNotFound.md
+++ b/packages/http-exception/docs/api/classes/client.HttpNotFound.md
@@ -31,7 +31,10 @@ unauthorized client.
 ### Properties
 
 - [cause](client.HttpNotFound.md#cause)
+- [code](client.HttpNotFound.md#code)
+- [errorId](client.HttpNotFound.md#errorid)
 - [message](client.HttpNotFound.md#message)
+- [method](client.HttpNotFound.md#method)
 - [name](client.HttpNotFound.md#name)
 - [stack](client.HttpNotFound.md#stack)
 - [statusCode](client.HttpNotFound.md#statuscode)
@@ -64,7 +67,7 @@ unauthorized client.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -79,6 +82,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -86,6 +113,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpPayloadTooLarge.md
+++ b/packages/http-exception/docs/api/classes/client.HttpPayloadTooLarge.md
@@ -28,7 +28,10 @@ Request entity is larger than limits defined by server. The server might close t
 ### Properties
 
 - [cause](client.HttpPayloadTooLarge.md#cause)
+- [code](client.HttpPayloadTooLarge.md#code)
+- [errorId](client.HttpPayloadTooLarge.md#errorid)
 - [message](client.HttpPayloadTooLarge.md#message)
+- [method](client.HttpPayloadTooLarge.md#method)
 - [name](client.HttpPayloadTooLarge.md#name)
 - [stack](client.HttpPayloadTooLarge.md#stack)
 - [statusCode](client.HttpPayloadTooLarge.md#statuscode)
@@ -61,7 +64,7 @@ Request entity is larger than limits defined by server. The server might close t
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpPaymentRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpPaymentRequired.md
@@ -29,7 +29,10 @@ payment systems, however this status code is used very rarely and no standard co
 ### Properties
 
 - [cause](client.HttpPaymentRequired.md#cause)
+- [code](client.HttpPaymentRequired.md#code)
+- [errorId](client.HttpPaymentRequired.md#errorid)
 - [message](client.HttpPaymentRequired.md#message)
+- [method](client.HttpPaymentRequired.md#method)
 - [name](client.HttpPaymentRequired.md#name)
 - [stack](client.HttpPaymentRequired.md#stack)
 - [statusCode](client.HttpPaymentRequired.md#statuscode)
@@ -62,7 +65,7 @@ payment systems, however this status code is used very rarely and no standard co
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpPreconditionFailed.md
+++ b/packages/http-exception/docs/api/classes/client.HttpPreconditionFailed.md
@@ -28,7 +28,10 @@ The client has indicated preconditions in its headers which the server does not 
 ### Properties
 
 - [cause](client.HttpPreconditionFailed.md#cause)
+- [code](client.HttpPreconditionFailed.md#code)
+- [errorId](client.HttpPreconditionFailed.md#errorid)
 - [message](client.HttpPreconditionFailed.md#message)
+- [method](client.HttpPreconditionFailed.md#method)
 - [name](client.HttpPreconditionFailed.md#name)
 - [stack](client.HttpPreconditionFailed.md#stack)
 - [statusCode](client.HttpPreconditionFailed.md#statuscode)
@@ -61,7 +64,7 @@ The client has indicated preconditions in its headers which the server does not 
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpPreconditionRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpPreconditionRequired.md
@@ -30,7 +30,10 @@ server, when meanwhile a third party has modified the state on the server, leadi
 ### Properties
 
 - [cause](client.HttpPreconditionRequired.md#cause)
+- [code](client.HttpPreconditionRequired.md#code)
+- [errorId](client.HttpPreconditionRequired.md#errorid)
 - [message](client.HttpPreconditionRequired.md#message)
+- [method](client.HttpPreconditionRequired.md#method)
 - [name](client.HttpPreconditionRequired.md#name)
 - [stack](client.HttpPreconditionRequired.md#stack)
 - [statusCode](client.HttpPreconditionRequired.md#statuscode)
@@ -63,7 +66,7 @@ server, when meanwhile a third party has modified the state on the server, leadi
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -78,6 +81,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -85,6 +112,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpProxyAuthenticationRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpProxyAuthenticationRequired.md
@@ -28,7 +28,10 @@ This is similar to 401 Unauthorized but authentication is needed to be done by a
 ### Properties
 
 - [cause](client.HttpProxyAuthenticationRequired.md#cause)
+- [code](client.HttpProxyAuthenticationRequired.md#code)
+- [errorId](client.HttpProxyAuthenticationRequired.md#errorid)
 - [message](client.HttpProxyAuthenticationRequired.md#message)
+- [method](client.HttpProxyAuthenticationRequired.md#method)
 - [name](client.HttpProxyAuthenticationRequired.md#name)
 - [stack](client.HttpProxyAuthenticationRequired.md#stack)
 - [statusCode](client.HttpProxyAuthenticationRequired.md#statuscode)
@@ -61,7 +64,7 @@ This is similar to 401 Unauthorized but authentication is needed to be done by a
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpRangeNotSatisfiable.md
+++ b/packages/http-exception/docs/api/classes/client.HttpRangeNotSatisfiable.md
@@ -29,7 +29,10 @@ It's possible that the range is outside the size of the target URI's data.
 ### Properties
 
 - [cause](client.HttpRangeNotSatisfiable.md#cause)
+- [code](client.HttpRangeNotSatisfiable.md#code)
+- [errorId](client.HttpRangeNotSatisfiable.md#errorid)
 - [message](client.HttpRangeNotSatisfiable.md#message)
+- [method](client.HttpRangeNotSatisfiable.md#method)
 - [name](client.HttpRangeNotSatisfiable.md#name)
 - [stack](client.HttpRangeNotSatisfiable.md#stack)
 - [statusCode](client.HttpRangeNotSatisfiable.md#statuscode)
@@ -62,7 +65,7 @@ It's possible that the range is outside the size of the target URI's data.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpRequestHeaderFieldsTooLarge.md
+++ b/packages/http-exception/docs/api/classes/client.HttpRequestHeaderFieldsTooLarge.md
@@ -29,7 +29,10 @@ The request may be resubmitted after reducing the size of the request header fie
 ### Properties
 
 - [cause](client.HttpRequestHeaderFieldsTooLarge.md#cause)
+- [code](client.HttpRequestHeaderFieldsTooLarge.md#code)
+- [errorId](client.HttpRequestHeaderFieldsTooLarge.md#errorid)
 - [message](client.HttpRequestHeaderFieldsTooLarge.md#message)
+- [method](client.HttpRequestHeaderFieldsTooLarge.md#method)
 - [name](client.HttpRequestHeaderFieldsTooLarge.md#name)
 - [stack](client.HttpRequestHeaderFieldsTooLarge.md#stack)
 - [statusCode](client.HttpRequestHeaderFieldsTooLarge.md#statuscode)
@@ -62,7 +65,7 @@ The request may be resubmitted after reducing the size of the request header fie
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpRequestTimeout.md
+++ b/packages/http-exception/docs/api/classes/client.HttpRequestTimeout.md
@@ -31,7 +31,10 @@ Also note that some servers merely shut down the connection without sending this
 ### Properties
 
 - [cause](client.HttpRequestTimeout.md#cause)
+- [code](client.HttpRequestTimeout.md#code)
+- [errorId](client.HttpRequestTimeout.md#errorid)
 - [message](client.HttpRequestTimeout.md#message)
+- [method](client.HttpRequestTimeout.md#method)
 - [name](client.HttpRequestTimeout.md#name)
 - [stack](client.HttpRequestTimeout.md#stack)
 - [statusCode](client.HttpRequestTimeout.md#statuscode)
@@ -64,7 +67,7 @@ Also note that some servers merely shut down the connection without sending this
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -79,6 +82,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -86,6 +113,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpTooEarly.md
+++ b/packages/http-exception/docs/api/classes/client.HttpTooEarly.md
@@ -27,7 +27,10 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425
 ### Properties
 
 - [cause](client.HttpTooEarly.md#cause)
+- [code](client.HttpTooEarly.md#code)
+- [errorId](client.HttpTooEarly.md#errorid)
 - [message](client.HttpTooEarly.md#message)
+- [method](client.HttpTooEarly.md#method)
 - [name](client.HttpTooEarly.md#name)
 - [stack](client.HttpTooEarly.md#stack)
 - [statusCode](client.HttpTooEarly.md#statuscode)
@@ -60,7 +63,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -75,6 +78,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -82,6 +109,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpTooManyRequests.md
+++ b/packages/http-exception/docs/api/classes/client.HttpTooManyRequests.md
@@ -28,7 +28,10 @@ The user has sent too many requests in a given amount of time ("rate limiting").
 ### Properties
 
 - [cause](client.HttpTooManyRequests.md#cause)
+- [code](client.HttpTooManyRequests.md#code)
+- [errorId](client.HttpTooManyRequests.md#errorid)
 - [message](client.HttpTooManyRequests.md#message)
+- [method](client.HttpTooManyRequests.md#method)
 - [name](client.HttpTooManyRequests.md#name)
 - [stack](client.HttpTooManyRequests.md#stack)
 - [statusCode](client.HttpTooManyRequests.md#statuscode)
@@ -61,7 +64,7 @@ The user has sent too many requests in a given amount of time ("rate limiting").
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpUnauthorized.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUnauthorized.md
@@ -29,7 +29,10 @@ That is, the client must authenticate itself to get the requested response.
 ### Properties
 
 - [cause](client.HttpUnauthorized.md#cause)
+- [code](client.HttpUnauthorized.md#code)
+- [errorId](client.HttpUnauthorized.md#errorid)
 - [message](client.HttpUnauthorized.md#message)
+- [method](client.HttpUnauthorized.md#method)
 - [name](client.HttpUnauthorized.md#name)
 - [stack](client.HttpUnauthorized.md#stack)
 - [statusCode](client.HttpUnauthorized.md#statuscode)
@@ -62,7 +65,7 @@ That is, the client must authenticate itself to get the requested response.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpUnavailableForLegalReasons.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUnavailableForLegalReasons.md
@@ -28,7 +28,10 @@ The user agent requested a resource that cannot legally be provided, such as a w
 ### Properties
 
 - [cause](client.HttpUnavailableForLegalReasons.md#cause)
+- [code](client.HttpUnavailableForLegalReasons.md#code)
+- [errorId](client.HttpUnavailableForLegalReasons.md#errorid)
 - [message](client.HttpUnavailableForLegalReasons.md#message)
+- [method](client.HttpUnavailableForLegalReasons.md#method)
 - [name](client.HttpUnavailableForLegalReasons.md#name)
 - [stack](client.HttpUnavailableForLegalReasons.md#stack)
 - [statusCode](client.HttpUnavailableForLegalReasons.md#statuscode)
@@ -61,7 +64,7 @@ The user agent requested a resource that cannot legally be provided, such as a w
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpUnprocessableEntity.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUnprocessableEntity.md
@@ -33,7 +33,10 @@ For example, this error condition may occur if an XML request body contains well
 ### Properties
 
 - [cause](client.HttpUnprocessableEntity.md#cause)
+- [code](client.HttpUnprocessableEntity.md#code)
+- [errorId](client.HttpUnprocessableEntity.md#errorid)
 - [message](client.HttpUnprocessableEntity.md#message)
+- [method](client.HttpUnprocessableEntity.md#method)
 - [name](client.HttpUnprocessableEntity.md#name)
 - [stack](client.HttpUnprocessableEntity.md#stack)
 - [statusCode](client.HttpUnprocessableEntity.md#statuscode)
@@ -66,7 +69,7 @@ For example, this error condition may occur if an XML request body contains well
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -81,6 +84,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -88,6 +115,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpUnsupportedMediaType.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUnsupportedMediaType.md
@@ -28,7 +28,10 @@ The media format of the requested data is not supported by the server, so the se
 ### Properties
 
 - [cause](client.HttpUnsupportedMediaType.md#cause)
+- [code](client.HttpUnsupportedMediaType.md#code)
+- [errorId](client.HttpUnsupportedMediaType.md#errorid)
 - [message](client.HttpUnsupportedMediaType.md#message)
+- [method](client.HttpUnsupportedMediaType.md#method)
 - [name](client.HttpUnsupportedMediaType.md#name)
 - [stack](client.HttpUnsupportedMediaType.md#stack)
 - [statusCode](client.HttpUnsupportedMediaType.md#statuscode)
@@ -61,7 +64,7 @@ The media format of the requested data is not supported by the server, so the se
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpUpgradeRequired.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUpgradeRequired.md
@@ -29,7 +29,10 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/426
 ### Properties
 
 - [cause](client.HttpUpgradeRequired.md#cause)
+- [code](client.HttpUpgradeRequired.md#code)
+- [errorId](client.HttpUpgradeRequired.md#errorid)
 - [message](client.HttpUpgradeRequired.md#message)
+- [method](client.HttpUpgradeRequired.md#method)
 - [name](client.HttpUpgradeRequired.md#name)
 - [stack](client.HttpUpgradeRequired.md#stack)
 - [statusCode](client.HttpUpgradeRequired.md#statuscode)
@@ -62,7 +65,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/426
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/client.HttpUriTooLong.md
+++ b/packages/http-exception/docs/api/classes/client.HttpUriTooLong.md
@@ -28,7 +28,10 @@ The URI requested by the client is longer than the server is willing to interpre
 ### Properties
 
 - [cause](client.HttpUriTooLong.md#cause)
+- [code](client.HttpUriTooLong.md#code)
+- [errorId](client.HttpUriTooLong.md#errorid)
 - [message](client.HttpUriTooLong.md#message)
+- [method](client.HttpUriTooLong.md#method)
 - [name](client.HttpUriTooLong.md#name)
 - [stack](client.HttpUriTooLong.md#stack)
 - [statusCode](client.HttpUriTooLong.md#statuscode)
@@ -61,7 +64,7 @@ The URI requested by the client is longer than the server is willing to interpre
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[code](base.HttpClientException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[errorId](base.HttpClientException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpClientException](base.HttpClientException.md).[message](base.HttpClientException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpClientException](base.HttpClientException.md).[method](base.HttpClientException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpBadGateway.md
+++ b/packages/http-exception/docs/api/classes/server.HttpBadGateway.md
@@ -28,7 +28,10 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502
 ### Properties
 
 - [cause](server.HttpBadGateway.md#cause)
+- [code](server.HttpBadGateway.md#code)
+- [errorId](server.HttpBadGateway.md#errorid)
 - [message](server.HttpBadGateway.md#message)
+- [method](server.HttpBadGateway.md#method)
 - [name](server.HttpBadGateway.md#name)
 - [stack](server.HttpBadGateway.md#stack)
 - [statusCode](server.HttpBadGateway.md#statuscode)
@@ -61,7 +64,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpGatewayTimeout.md
+++ b/packages/http-exception/docs/api/classes/server.HttpGatewayTimeout.md
@@ -28,7 +28,10 @@ This error response is given when the server is acting as a gateway and cannot g
 ### Properties
 
 - [cause](server.HttpGatewayTimeout.md#cause)
+- [code](server.HttpGatewayTimeout.md#code)
+- [errorId](server.HttpGatewayTimeout.md#errorid)
 - [message](server.HttpGatewayTimeout.md#message)
+- [method](server.HttpGatewayTimeout.md#method)
 - [name](server.HttpGatewayTimeout.md#name)
 - [stack](server.HttpGatewayTimeout.md#stack)
 - [statusCode](server.HttpGatewayTimeout.md#statuscode)
@@ -61,7 +64,7 @@ This error response is given when the server is acting as a gateway and cannot g
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpInsufficientStorage.md
+++ b/packages/http-exception/docs/api/classes/server.HttpInsufficientStorage.md
@@ -28,7 +28,10 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/507
 ### Properties
 
 - [cause](server.HttpInsufficientStorage.md#cause)
+- [code](server.HttpInsufficientStorage.md#code)
+- [errorId](server.HttpInsufficientStorage.md#errorid)
 - [message](server.HttpInsufficientStorage.md#message)
+- [method](server.HttpInsufficientStorage.md#method)
 - [name](server.HttpInsufficientStorage.md#name)
 - [stack](server.HttpInsufficientStorage.md#stack)
 - [statusCode](server.HttpInsufficientStorage.md#statuscode)
@@ -61,7 +64,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/507
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpInternalServerError.md
+++ b/packages/http-exception/docs/api/classes/server.HttpInternalServerError.md
@@ -28,7 +28,10 @@ The server has encountered a situation it does not know how to handle.
 ### Properties
 
 - [cause](server.HttpInternalServerError.md#cause)
+- [code](server.HttpInternalServerError.md#code)
+- [errorId](server.HttpInternalServerError.md#errorid)
 - [message](server.HttpInternalServerError.md#message)
+- [method](server.HttpInternalServerError.md#method)
 - [name](server.HttpInternalServerError.md#name)
 - [stack](server.HttpInternalServerError.md#stack)
 - [statusCode](server.HttpInternalServerError.md#statuscode)
@@ -61,7 +64,7 @@ The server has encountered a situation it does not know how to handle.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpLoopDetected.md
+++ b/packages/http-exception/docs/api/classes/server.HttpLoopDetected.md
@@ -28,7 +28,10 @@ The server detected an infinite loop while processing the request.
 ### Properties
 
 - [cause](server.HttpLoopDetected.md#cause)
+- [code](server.HttpLoopDetected.md#code)
+- [errorId](server.HttpLoopDetected.md#errorid)
 - [message](server.HttpLoopDetected.md#message)
+- [method](server.HttpLoopDetected.md#method)
 - [name](server.HttpLoopDetected.md#name)
 - [stack](server.HttpLoopDetected.md#stack)
 - [statusCode](server.HttpLoopDetected.md#statuscode)
@@ -61,7 +64,7 @@ The server detected an infinite loop while processing the request.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpNetworkAuthenticationRequired.md
+++ b/packages/http-exception/docs/api/classes/server.HttpNetworkAuthenticationRequired.md
@@ -28,7 +28,10 @@ Indicates that the client needs to authenticate to gain network access.
 ### Properties
 
 - [cause](server.HttpNetworkAuthenticationRequired.md#cause)
+- [code](server.HttpNetworkAuthenticationRequired.md#code)
+- [errorId](server.HttpNetworkAuthenticationRequired.md#errorid)
 - [message](server.HttpNetworkAuthenticationRequired.md#message)
+- [method](server.HttpNetworkAuthenticationRequired.md#method)
 - [name](server.HttpNetworkAuthenticationRequired.md#name)
 - [stack](server.HttpNetworkAuthenticationRequired.md#stack)
 - [statusCode](server.HttpNetworkAuthenticationRequired.md#statuscode)
@@ -61,7 +64,7 @@ Indicates that the client needs to authenticate to gain network access.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpNotExtended.md
+++ b/packages/http-exception/docs/api/classes/server.HttpNotExtended.md
@@ -28,7 +28,10 @@ Further extensions to the request are required for the server to fulfill it.
 ### Properties
 
 - [cause](server.HttpNotExtended.md#cause)
+- [code](server.HttpNotExtended.md#code)
+- [errorId](server.HttpNotExtended.md#errorid)
 - [message](server.HttpNotExtended.md#message)
+- [method](server.HttpNotExtended.md#method)
 - [name](server.HttpNotExtended.md#name)
 - [stack](server.HttpNotExtended.md#stack)
 - [statusCode](server.HttpNotExtended.md#statuscode)
@@ -61,7 +64,7 @@ Further extensions to the request are required for the server to fulfill it.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpNotImplemented.md
+++ b/packages/http-exception/docs/api/classes/server.HttpNotImplemented.md
@@ -29,7 +29,10 @@ servers are required to support (and therefore that must not return this code) a
 ### Properties
 
 - [cause](server.HttpNotImplemented.md#cause)
+- [code](server.HttpNotImplemented.md#code)
+- [errorId](server.HttpNotImplemented.md#errorid)
 - [message](server.HttpNotImplemented.md#message)
+- [method](server.HttpNotImplemented.md#method)
 - [name](server.HttpNotImplemented.md#name)
 - [stack](server.HttpNotImplemented.md#stack)
 - [statusCode](server.HttpNotImplemented.md#statuscode)
@@ -62,7 +65,7 @@ servers are required to support (and therefore that must not return this code) a
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpServiceUnavailable.md
+++ b/packages/http-exception/docs/api/classes/server.HttpServiceUnavailable.md
@@ -35,7 +35,10 @@ should usually not be cached.
 ### Properties
 
 - [cause](server.HttpServiceUnavailable.md#cause)
+- [code](server.HttpServiceUnavailable.md#code)
+- [errorId](server.HttpServiceUnavailable.md#errorid)
 - [message](server.HttpServiceUnavailable.md#message)
+- [method](server.HttpServiceUnavailable.md#method)
 - [name](server.HttpServiceUnavailable.md#name)
 - [stack](server.HttpServiceUnavailable.md#stack)
 - [statusCode](server.HttpServiceUnavailable.md#statuscode)
@@ -68,7 +71,7 @@ should usually not be cached.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -83,6 +86,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -90,6 +117,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpVariantAlsoNegotiates.md
+++ b/packages/http-exception/docs/api/classes/server.HttpVariantAlsoNegotiates.md
@@ -29,7 +29,10 @@ in transparent content negotiation itself, and is therefore not a proper end poi
 ### Properties
 
 - [cause](server.HttpVariantAlsoNegotiates.md#cause)
+- [code](server.HttpVariantAlsoNegotiates.md#code)
+- [errorId](server.HttpVariantAlsoNegotiates.md#errorid)
 - [message](server.HttpVariantAlsoNegotiates.md#message)
+- [method](server.HttpVariantAlsoNegotiates.md#method)
 - [name](server.HttpVariantAlsoNegotiates.md#name)
 - [stack](server.HttpVariantAlsoNegotiates.md#stack)
 - [statusCode](server.HttpVariantAlsoNegotiates.md#statuscode)
@@ -62,7 +65,7 @@ in transparent content negotiation itself, and is therefore not a proper end poi
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -77,6 +80,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -84,6 +111,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/classes/server.HttpVersionNotSupported.md
+++ b/packages/http-exception/docs/api/classes/server.HttpVersionNotSupported.md
@@ -28,7 +28,10 @@ The HTTP version used in the request is not supported by the server.
 ### Properties
 
 - [cause](server.HttpVersionNotSupported.md#cause)
+- [code](server.HttpVersionNotSupported.md#code)
+- [errorId](server.HttpVersionNotSupported.md#errorid)
 - [message](server.HttpVersionNotSupported.md#message)
+- [method](server.HttpVersionNotSupported.md#method)
 - [name](server.HttpVersionNotSupported.md#name)
 - [stack](server.HttpVersionNotSupported.md#stack)
 - [statusCode](server.HttpVersionNotSupported.md#statuscode)
@@ -61,7 +64,7 @@ The HTTP version used in the request is not supported by the server.
 
 ### cause
 
-• `Optional` `Readonly` **cause**: `Error`
+• `Optional` `Readonly` **cause**: `Error` \| [`HttpException`](base.HttpException.md)
 
 If set and the runtime (browser or node) supports it
 you can get back the error cause
@@ -76,6 +79,30 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
 ---
 
+### code
+
+• `Readonly` **code**: `undefined` \| `string`
+
+Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[code](base.HttpServerException.md#code)
+
+---
+
+### errorId
+
+• `Readonly` **errorId**: `undefined` \| `string`
+
+Inform about an unique error identifier (ie: nanoid, cuid...)
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[errorId](base.HttpServerException.md#errorid)
+
+---
+
 ### message
 
 • **message**: `string`
@@ -83,6 +110,18 @@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 #### Inherited from
 
 [HttpServerException](base.HttpServerException.md).[message](base.HttpServerException.md#message)
+
+---
+
+### method
+
+• `Readonly` **method**: `undefined` \| [`HttpMethod`](../modules/types.md#httpmethod)
+
+Http method
+
+#### Inherited from
+
+[HttpServerException](base.HttpServerException.md).[method](base.HttpServerException.md#method)
 
 ---
 

--- a/packages/http-exception/docs/api/modules/serializer.md
+++ b/packages/http-exception/docs/api/modules/serializer.md
@@ -11,9 +11,14 @@
 ### Type Aliases
 
 - [NativeError](serializer.md#nativeerror)
+- [SerializableError](serializer.md#serializableerror)
+- [SerializableHttpException](serializer.md#serializablehttpexception)
+- [SerializableNonNativeError](serializer.md#serializablenonnativeerror)
 
 ### Functions
 
+- [convertToSerializable](serializer.md#converttoserializable)
+- [createFromSerializable](serializer.md#createfromserializable)
 - [fromJson](serializer.md#fromjson)
 - [toJson](serializer.md#tojson)
 
@@ -23,14 +28,67 @@
 
 Ƭ **NativeError**: `Error` \| `EvalError` \| `RangeError` \| `ReferenceError` \| `SyntaxError` \| `TypeError` \| `URIError`
 
-Supported native ecmascript errors
+---
 
-**`See`**
+### SerializableError
 
-- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types
-- https://262.ecma-international.org/12.0/#sec-well-known-intrinsic-objects
+Ƭ **SerializableError**: `DiscriminateSerializable`<`"NativeError"`\>
+
+---
+
+### SerializableHttpException
+
+Ƭ **SerializableHttpException**: `DiscriminateSerializable`<`"HttpException"`\>
+
+---
+
+### SerializableNonNativeError
+
+Ƭ **SerializableNonNativeError**: `DiscriminateSerializable`<`"NonNativeError"`\>
 
 ## Functions
+
+### convertToSerializable
+
+▸ **convertToSerializable**(`e`): `Serializable`
+
+Convert an Error, NativeError or any HttpException to
+an object suitable for serialization (a serializable version).
+
+**`Link`**
+
+#### Parameters
+
+| Name | Type                                                                                              |
+| :--- | :------------------------------------------------------------------------------------------------ |
+| `e`  | [`HttpException`](../classes/base.HttpException.md) \| [`NativeError`](serializer.md#nativeerror) |
+
+#### Returns
+
+`Serializable`
+
+---
+
+### createFromSerializable
+
+▸ **createFromSerializable**(`payload`): [`HttpException`](../classes/base.HttpException.md) \| [`NativeError`](serializer.md#nativeerror)
+
+create an Error, NativeError or any HttpException from a
+serializable representation
+
+**`Link`**
+
+#### Parameters
+
+| Name      | Type           |
+| :-------- | :------------- |
+| `payload` | `Serializable` |
+
+#### Returns
+
+[`HttpException`](../classes/base.HttpException.md) \| [`NativeError`](serializer.md#nativeerror)
+
+---
 
 ### fromJson
 

--- a/packages/http-exception/docs/api/modules/types.md
+++ b/packages/http-exception/docs/api/modules/types.md
@@ -9,6 +9,7 @@
 - [AssignedStatusCodes](types.md#assignedstatuscodes)
 - [HttpExceptionParams](types.md#httpexceptionparams)
 - [HttpExceptionParamsWithStatus](types.md#httpexceptionparamswithstatus)
+- [HttpMethod](types.md#httpmethod)
 - [HttpStatusCode](types.md#httpstatuscode)
 
 ## Type Aliases
@@ -25,17 +26,26 @@
 
 #### Type declaration
 
-| Name       | Type     | Description                                                                                                                                                                                                                                                            |
-| :--------- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cause?`   | `Error`  | Indicates the original cause of the HttpException. Will be ignored/discarded if the runtime (browser / node version) does not support it or there's no polyfill **`See`** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause |
-| `message?` | `string` | Exception message, if not provided the default is the exception name in natural language (ie: "HttpNotFound" -> "Not found")                                                                                                                                           |
-| `url?`     | `string` | Indicates the original url that caused the error.                                                                                                                                                                                                                      |
+| Name       | Type                                                                                                             | Description                                                                                                                                                                                                                                                            |
+| :--------- | :--------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cause?`   | `Error`                                                                                                          | Indicates the original cause of the HttpException. Will be ignored/discarded if the runtime (browser / node version) does not support it or there's no polyfill **`See`** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause |
+| `code?`    | `string`                                                                                                         | Custom additional code (ie: 'AbortError', 'CODE-1234'...)                                                                                                                                                                                                              |
+| `errorId?` | `string`                                                                                                         | Inform about an unique error identifier (ie: nanoid, cuid...)                                                                                                                                                                                                          |
+| `message?` | `string`                                                                                                         | Exception message, if not provided the default is the exception name in natural language (ie: "HttpNotFound" -> "Not found")                                                                                                                                           |
+| `method?`  | `"GET"` \| `"HEAD"` \| `"POST"` \| `"PUT"` \| `"DELETE"` \| `"CONNECT"` \| `"OPTIONS"` \| `"TRACE"` \| `"PATCH"` | Inform about http method                                                                                                                                                                                                                                               |
+| `url?`     | `string`                                                                                                         | Indicates the original url that caused the error.                                                                                                                                                                                                                      |
 
 ---
 
 ### HttpExceptionParamsWithStatus
 
 Ƭ **HttpExceptionParamsWithStatus**: [`HttpExceptionParams`](types.md#httpexceptionparams) & { `statusCode`: [`HttpStatusCode`](types.md#httpstatuscode) }
+
+---
+
+### HttpMethod
+
+Ƭ **HttpMethod**: `"GET"` \| `"HEAD"` \| `"POST"` \| `"PUT"` \| `"DELETE"` \| `"CONNECT"` \| `"OPTIONS"` \| `"TRACE"` \| `"PATCH"`
 
 ---
 

--- a/packages/http-exception/src/base/HttpException.ts
+++ b/packages/http-exception/src/base/HttpException.ts
@@ -1,5 +1,5 @@
 import { supportsErrorCause } from '../support';
-import type { HttpExceptionParams } from '../types';
+import type { HttpExceptionParams, HttpMethod } from '../types';
 import { getSuper } from '../utils';
 
 export class HttpException extends Error {
@@ -13,11 +13,26 @@ export class HttpException extends Error {
   public readonly url: string | undefined;
 
   /**
+   * Http method
+   */
+  public readonly method: HttpMethod | undefined;
+
+  /**
+   * Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+   */
+  public readonly code: string | undefined;
+
+  /**
+   * Inform about an unique error identifier (ie: nanoid, cuid...)
+   */
+  public readonly errorId: string | undefined;
+
+  /**
    * If set and the runtime (browser or node) supports it
    * you can get back the error cause
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
    */
-  public readonly cause?: Error;
+  public readonly cause?: Error | HttpException;
 
   /**
    * Construct a new HttpException class
@@ -27,14 +42,20 @@ export class HttpException extends Error {
    */
   constructor(statusCode: number, msgOrParams?: HttpExceptionParams | string) {
     const name = 'HttpException';
-    const { message, url, cause } = getSuper(name, msgOrParams);
+    const { message, url, cause, errorId, code, method } = getSuper(
+      name,
+      msgOrParams
+    );
     if (supportsErrorCause() && cause) {
       super(message, { cause });
     } else {
       super(message);
     }
-    this.url = url;
     this.statusCode = statusCode;
+    this.url = url;
+    this.errorId = errorId;
+    this.code = code;
+    this.method = method;
     Object.setPrototypeOf(this, HttpException.prototype);
     this.name = name;
   }

--- a/packages/http-exception/src/base/__tests__/HttpException.test.ts
+++ b/packages/http-exception/src/base/__tests__/HttpException.test.ts
@@ -1,3 +1,4 @@
+import type { HttpExceptionParams } from '../../types';
 import { HttpException } from '../HttpException';
 
 describe('HttpException', () => {
@@ -16,12 +17,20 @@ describe('HttpException', () => {
     expect(exception.stack).toStrictEqual(expect.any(String));
     expect(exception.cause).toBeUndefined();
   });
-  it('should persist url and statusCode', () => {
-    const exception = new HttpException(500, {
-      message: 'test',
-      url: 'https://localhost',
-    });
-    expect(exception.url).toStrictEqual('https://localhost');
+  it('should persist statusCode and params', () => {
+    const params: HttpExceptionParams = {
+      errorId: 'nanoid()',
+      message: 'msg',
+      code: 'NETWORK_UNAVAILABLE',
+      url: 'http://localhost',
+      method: 'PUT',
+    };
+    const exception = new HttpException(500, params);
+    expect(exception.url).toStrictEqual(params.url);
+    expect(exception.errorId).toStrictEqual(params.errorId);
+    expect(exception.message).toStrictEqual(params.message);
+    expect(exception.code).toStrictEqual(params.code);
+    expect(exception.method).toStrictEqual(params.method);
     expect(exception.statusCode).toStrictEqual(500);
   });
   it('should support sending a cause', () => {

--- a/packages/http-exception/src/serializer/mapper/__tests__/__snapshots__/convertToSerializable.test.ts.snap
+++ b/packages/http-exception/src/serializer/mapper/__tests__/__snapshots__/convertToSerializable.test.ts.snap
@@ -36,6 +36,19 @@ exports[`convertToSerializable > when an http exception is given > works with wi
 }
 `;
 
+exports[`convertToSerializable > when an http exception is given > works with withFullParams 1`] = `
+{
+  "__type": "HttpException",
+  "code": "NETWORK_UNAVAILABLE",
+  "errorId": "nanoid()",
+  "message": "msg",
+  "method": "PUT",
+  "name": "HttpException",
+  "statusCode": 500,
+  "url": "http://localhost",
+}
+`;
+
 exports[`convertToSerializable > when an http exception is given > works with withMsg 1`] = `
 {
   "__type": "HttpException",

--- a/packages/http-exception/src/serializer/mapper/__tests__/convertToSerializable.test.ts
+++ b/packages/http-exception/src/serializer/mapper/__tests__/convertToSerializable.test.ts
@@ -9,6 +9,16 @@ describe('convertToSerializable', () => {
       ['simple', new HttpException(500)],
       ['withMsg', new HttpException(500, 'msg')],
       [
+        'withFullParams',
+        new HttpException(500, {
+          errorId: 'nanoid()',
+          message: 'msg',
+          code: 'NETWORK_UNAVAILABLE',
+          url: 'http://localhost',
+          method: 'PUT',
+        }),
+      ],
+      [
         'withCause',
         new HttpException(500, {
           cause: new HttpException(500, 'msg'),
@@ -32,6 +42,9 @@ describe('convertToSerializable', () => {
       expect(serializable.message).toStrictEqual(err.message);
       expect(serializable.name).toStrictEqual(err.name);
       expect(serializable?.url).toStrictEqual(err?.url);
+      expect(serializable?.code).toStrictEqual(err?.code);
+      expect(serializable?.errorId).toStrictEqual(err?.errorId);
+      expect(serializable?.method).toStrictEqual(err?.method);
       const { cause, stack, ...serializableWithoutCause } = serializable;
       expect(serializableWithoutCause).toMatchSnapshot();
     });

--- a/packages/http-exception/src/serializer/mapper/__tests__/createFromSerializable.test.ts
+++ b/packages/http-exception/src/serializer/mapper/__tests__/createFromSerializable.test.ts
@@ -9,6 +9,16 @@ describe('createFromSerializable', () => {
       ['simple', new HttpException(500)],
       ['withMsg', new HttpException(500, 'msg')],
       [
+        'withFullParams',
+        new HttpException(500, {
+          errorId: 'nanoid()',
+          message: 'msg',
+          code: 'NETWORK_UNAVAILABLE',
+          url: 'http://localhost',
+          method: 'PUT',
+        }),
+      ],
+      [
         'withCause',
         new HttpException(500, {
           cause: new HttpException(500, 'msg'),
@@ -29,6 +39,12 @@ describe('createFromSerializable', () => {
       (label, err) => {
         const converted = createFromSerializable(convertToSerializable(err));
         expect(converted).toStrictEqual(err);
+        expect((converted as HttpException)?.url).toStrictEqual(err.url);
+        expect((converted as HttpException)?.method).toStrictEqual(err.method);
+        expect((converted as HttpException)?.errorId).toStrictEqual(
+          err.errorId
+        );
+        expect((converted as HttpException)?.code).toStrictEqual(err.code);
       }
     );
   });

--- a/packages/http-exception/src/serializer/mapper/convertToSerializable.ts
+++ b/packages/http-exception/src/serializer/mapper/convertToSerializable.ts
@@ -11,6 +11,7 @@ import type { NativeError, Serializable } from '../types';
  */
 export const convertToSerializable = (
   e: Error | NativeError | HttpException
+  // eslint-disable-next-line sonarjs/cognitive-complexity
 ): Serializable => {
   const {
     name,
@@ -41,6 +42,9 @@ export const convertToSerializable = (
       ...common,
       statusCode: e.statusCode,
       ...(e.url ? { url: e.url } : {}),
+      ...(e.code ? { code: e.code } : {}),
+      ...(e.method ? { method: e.method } : {}),
+      ...(e.errorId ? { errorId: e.errorId } : {}),
     };
   }
   return {

--- a/packages/http-exception/src/serializer/mapper/createFromSerializable.ts
+++ b/packages/http-exception/src/serializer/mapper/createFromSerializable.ts
@@ -39,6 +39,9 @@ const createHttpExceptionError = (
   const params = {
     message: serializable.message,
     url: serializable.url,
+    method: serializable.method,
+    errorId: serializable.errorId,
+    code: serializable.code,
     cause: cause ? createFromSerializable(cause) : undefined,
   };
   let e: HttpException;

--- a/packages/http-exception/src/serializer/types/index.ts
+++ b/packages/http-exception/src/serializer/types/index.ts
@@ -3,6 +3,7 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types
  * @see https://262.ecma-international.org/12.0/#sec-well-known-intrinsic-objects
  */
+import type { HttpMethod } from '../../types';
 
 export type NativeError =
   | Error
@@ -30,6 +31,9 @@ export type NativeErrorFields = {
 export type HttpExceptionFields = NativeErrorFields & {
   statusCode: number;
   url?: string;
+  method?: HttpMethod;
+  errorId?: string;
+  code?: string;
 };
 
 export type Serializable =

--- a/packages/http-exception/src/types/HttpExceptionParams.ts
+++ b/packages/http-exception/src/types/HttpExceptionParams.ts
@@ -8,6 +8,31 @@ export type HttpExceptionParams = {
    * Indicates the original url that caused the error.
    */
   url?: string;
+
+  /**
+   * Inform about http method
+   */
+  method?:
+    | 'GET'
+    | 'HEAD'
+    | 'POST'
+    | 'PUT'
+    | 'DELETE'
+    | 'CONNECT'
+    | 'OPTIONS'
+    | 'TRACE'
+    | 'PATCH';
+
+  /**
+   * Custom additional code (ie: 'AbortError', 'CODE-1234'...)
+   */
+  code?: string;
+
+  /**
+   * Inform about an unique error identifier (ie: nanoid, cuid...)
+   */
+  errorId?: string;
+
   /**
    * Indicates the original cause of the HttpException.
    * Will be ignored/discarded if the runtime (browser / node version) does not support it

--- a/packages/http-exception/src/types/HttpMethod.ts
+++ b/packages/http-exception/src/types/HttpMethod.ts
@@ -1,0 +1,10 @@
+export type HttpMethod =
+  | 'GET'
+  | 'HEAD'
+  | 'POST'
+  | 'PUT'
+  | 'DELETE'
+  | 'CONNECT'
+  | 'OPTIONS'
+  | 'TRACE'
+  | 'PATCH';

--- a/packages/http-exception/src/types/index.ts
+++ b/packages/http-exception/src/types/index.ts
@@ -1,4 +1,5 @@
 export type { HttpExceptionParams } from './HttpExceptionParams';
 export type { HttpExceptionParamsWithStatus } from './HttpExceptionParamsWithStatus';
 export type { HttpStatusCode } from './HttpStatusCode';
+export type { HttpMethod } from './HttpMethod';
 export type { AssignedStatusCodes } from './AssignedStatusCodes';

--- a/packages/http-exception/src/utils/getSuper.ts
+++ b/packages/http-exception/src/utils/getSuper.ts
@@ -15,6 +15,13 @@ export const getSuper = (
 ): HttpExceptionParams => {
   const p =
     typeof msgOrParams === 'string' ? { message: msgOrParams } : msgOrParams;
-  const { message = getMsgFromCls(name), url, cause } = p ?? {};
-  return { message, url, cause };
+  const {
+    message = getMsgFromCls(name),
+    url,
+    cause,
+    errorId,
+    code,
+    method,
+  } = p ?? {};
+  return { message, url, cause, errorId, code, method };
 };


### PR DESCRIPTION
Added `method`, `code` and `errorId` params.

| Name      | Type      | Description                                           |
|-----------| --------- |-------------------------------------------------------|
| url       | `string?` | url on which the error happened                       |
| method    | `string?` | http method used to load the url                      |
| code      | `string?` | Custom code (ie: 'AbortError', 'E-1234'...) |
| errorId   | `string?` | Unique error identifier (ie: uuid, nanoid...)         |

```typescript
const err = new HttpRequestTimeout({
  url: "https://api.dev/user/belgattitude",
  method: "GET",
  code: "NETWORK_FAILURE",
  errorId: nanoid(), // can be shared by frontend/backend 
});
console.log(err.url, err.method, err.code, err.errorId);
```
