### PR TITLE
Reproduction issue with vite 3.1.4

### DIFF
--- a/packages/http-exception/package.json
+++ b/packages/http-exception/package.json
@@ -131,7 +131,7 @@
     "typedoc": "0.23.15",
     "typedoc-plugin-markdown": "3.13.6",
     "typescript": "4.8.4",
-    "vite": "3.1.3",
+    "vite": "3.1.4",
     "vite-tsconfig-paths": "3.5.1",
     "vitest": "0.23.4",
     "webpack": "5.74.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,7 +1562,7 @@ __metadata:
     typedoc: "npm:0.23.15"
     typedoc-plugin-markdown: "npm:3.13.6"
     typescript: "npm:4.8.4"
-    vite: "npm:3.1.3"
+    vite: "npm:3.1.4"
     vite-tsconfig-paths: "npm:3.5.1"
     vitest: "npm:0.23.4"
     webpack: "npm:5.74.0"
@@ -14750,9 +14750,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:3.1.3, vite@npm:^2.9.12 || ^3.0.0-0":
-  version: 3.1.3
-  resolution: "vite@npm:3.1.3"
+"vite@npm:3.1.4, vite@npm:^2.9.12 || ^3.0.0-0":
+  version: 3.1.4
+  resolution: "vite@npm:3.1.4"
   dependencies:
     esbuild: "npm:^0.15.6"
     fsevents: "npm:~2.3.2"
@@ -14778,7 +14778,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: c0770a1de3d54b11cb6ae468d2d4dd558d339bae88cf7544a763420694fb171a7650fac76692ba5f8923bb3329912a6450cd8717c92b1032b46b2a185617dbc1
+  checksum: dcaa8fcec26f791bf15664402fecc8a99c890a25c1e7381f1b67b16588450e0df0ffbeff25264de2654902a42dfad72d6830148d44bcfa08774012a19707b41e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> **Vite issue**: https://github.com/vitejs/vite/issues/10292
> **Upstream changes**: https://github.com/vitejs/vite/pull/10215 and https://github.com/vitejs/vite/pull/10207
> **easy fix**: set target to node14in vitest

Possible regression with vite 3.1.4 (move to esnext) ?

```
yarn install
cd packages/http-exception
yarn test-unit
```

Failing test:

https://github.com/belgattitude/http-exception/blob/599fa76113c3fc53c71e935133f52cabe13423cf/packages/http-exception/src/base/__tests__/HttpException.test.ts#L36-L48


![image](https://user-images.githubusercontent.com/259798/193158403-a14eb28d-ee40-4ac9-9bff-2264aa302d32.png)


Easy workaround:

Change the target to 'node14 or later' in vitest esbuild config 

Done in https://github.com/belgattitude/http-exception/pull/82 - https://github.com/belgattitude/http-exception/pull/82/files#diff-bf307cafcebcb7d56cd0b4a3017f12f6a1ba9a768ecd1de52df5c77158cf2e78